### PR TITLE
Add OnConnRecycle hook

### DIFF
--- a/armbalancer_test.go
+++ b/armbalancer_test.go
@@ -154,6 +154,8 @@ func TestHooks(t *testing.T) {
 		resp.Body.Close()
 	}
 
+	lock.Lock()
+	defer lock.Unlock()
 	if recycleHookCalls == 0 {
 		t.Error("OnConnRecycle was not called")
 	}


### PR DESCRIPTION
Adds a hook that allows callers to emit trace events or logs when armbalancer recycles connections. Useful for determining why a connection was recycled, how long it lived, and how long it took to drain.